### PR TITLE
feat: Cloud Run デプロイ設定整備 (#4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github
 .next
 .husky
+.claude
 node_modules
 *.md
 *.test.ts
@@ -11,3 +12,7 @@ node_modules
 Makefile
 .env*
 !.env.example
+# seed スクリプトは本番イメージに含めない
+prisma/seed.ts
+# カバレッジ・テスト成果物
+coverage

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,12 @@ env:
   REGION: asia-northeast1
   SERVICE_NAME: daily-report
   REGISTRY: asia-northeast1-docker.pkg.dev
+  CLOUDSQL_INSTANCE: daily-report-db
+  SECRET_DATABASE_URL: daily-report-database-url
+  SECRET_NEXTAUTH_SECRET: daily-report-nextauth-secret
+  # GitHub リポジトリ設定の Variables に NEXTAUTH_URL を登録すること
+  # Settings > Secrets and variables > Actions > Variables > New repository variable
+  NEXTAUTH_URL: ${{ vars.NEXTAUTH_URL }}
 
 jobs:
   deploy:
@@ -49,9 +55,16 @@ jobs:
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy ${{ env.SERVICE_NAME }} \
-            --image ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}/${{ env.SERVICE_NAME }}:${{ github.sha }} \
-            --region ${{ env.REGION }} \
-            --project ${{ env.PROJECT_ID }} \
-            --platform managed \
+            --image=${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}/${{ env.SERVICE_NAME }}:${{ github.sha }} \
+            --region=${{ env.REGION }} \
+            --project=${{ env.PROJECT_ID }} \
+            --platform=managed \
             --allow-unauthenticated \
-            --set-env-vars DATABASE_URL=${{ secrets.DATABASE_URL }}
+            --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.CLOUDSQL_INSTANCE }} \
+            --set-secrets=DATABASE_URL=${{ env.SECRET_DATABASE_URL }}:latest,NEXTAUTH_SECRET=${{ env.SECRET_NEXTAUTH_SECRET }}:latest \
+            --set-env-vars=NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NODE_ENV=production \
+            --memory=512Mi \
+            --cpu=1 \
+            --min-instances=0 \
+            --max-instances=10 \
+            --timeout=60

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Prisma Client を生成してから Next.js をビルド
+# DATABASE_URL はビルド時には不要（接続しないため dummy を渡す）
+RUN DATABASE_URL=postgresql://dummy:dummy@localhost:5432/dummy \
+    npx prisma generate --config prisma/config.ts
 RUN npm run build
 
 # ---- runner ----

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-PROJECT_ID   := daily-report-491906
-REGION       := asia-northeast1
-SERVICE_NAME := daily-report
-REGISTRY     := asia-northeast1-docker.pkg.dev
-IMAGE        := $(REGISTRY)/$(PROJECT_ID)/$(SERVICE_NAME)/$(SERVICE_NAME)
-TAG          := $(shell git rev-parse --short HEAD)
+PROJECT_ID      := daily-report-491906
+REGION          := asia-northeast1
+SERVICE_NAME    := daily-report
+REGISTRY        := asia-northeast1-docker.pkg.dev
+CLOUDSQL_INSTANCE := daily-report-db
+IMAGE           := $(REGISTRY)/$(PROJECT_ID)/$(SERVICE_NAME)/$(SERVICE_NAME)
+TAG             := $(shell git rev-parse --short HEAD)
 
-.PHONY: lint test build push deploy all
+.PHONY: lint test build push deploy migrate seed proxy all help
 
 ## lint: ESLint + Prettier チェック
 lint:
@@ -28,11 +29,31 @@ push:
 ## deploy: Cloud Run へデプロイ
 deploy:
 	gcloud run deploy $(SERVICE_NAME) \
-		--image $(IMAGE):$(TAG) \
-		--region $(REGION) \
-		--project $(PROJECT_ID) \
-		--platform managed \
-		--allow-unauthenticated
+		--image=$(IMAGE):$(TAG) \
+		--region=$(REGION) \
+		--project=$(PROJECT_ID) \
+		--platform=managed \
+		--allow-unauthenticated \
+		--add-cloudsql-instances=$(PROJECT_ID):$(REGION):$(CLOUDSQL_INSTANCE) \
+		--set-secrets=DATABASE_URL=daily-report-database-url:latest,NEXTAUTH_SECRET=daily-report-nextauth-secret:latest \
+		--memory=512Mi \
+		--cpu=1 \
+		--min-instances=0 \
+		--max-instances=10
+
+## proxy: Cloud SQL Auth Proxy を起動（ローカル開発用）
+## 事前に cloud-sql-proxy のインストールが必要:
+##   https://cloud.google.com/sql/docs/postgres/connect-instance-auth-proxy
+proxy:
+	cloud-sql-proxy $(PROJECT_ID):$(REGION):$(CLOUDSQL_INSTANCE) --port=5432
+
+## migrate: Cloud SQL に対してマイグレーションを実行（proxy 起動中に実行）
+migrate:
+	npx prisma migrate deploy --config prisma/config.ts
+
+## seed: Cloud SQL にシードデータを投入（proxy 起動中に実行）
+seed:
+	npx prisma db seed --config prisma/config.ts
 
 ## all: lint → test → build → push → deploy
 all: lint test build push deploy

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,54 @@
+steps:
+  # Docker イメージをビルド
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      - build
+      - "-t"
+      - "${_REGISTRY}/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:${SHORT_SHA}"
+      - "-t"
+      - "${_REGISTRY}/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:latest"
+      - "."
+
+  # Artifact Registry へプッシュ
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      - push
+      - "--all-tags"
+      - "${_REGISTRY}/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}"
+
+  # Cloud Run へデプロイ
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - "${_SERVICE_NAME}"
+      - "--image=${_REGISTRY}/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:${SHORT_SHA}"
+      - "--region=${_REGION}"
+      - "--platform=managed"
+      - "--allow-unauthenticated"
+      - "--add-cloudsql-instances=${PROJECT_ID}:${_REGION}:${_CLOUDSQL_INSTANCE}"
+      - "--set-secrets=DATABASE_URL=${_SECRET_DATABASE_URL}:latest,NEXTAUTH_SECRET=${_SECRET_NEXTAUTH_SECRET}:latest"
+      - "--set-env-vars=NEXTAUTH_URL=${_NEXTAUTH_URL},NODE_ENV=production"
+      - "--memory=512Mi"
+      - "--cpu=1"
+      - "--min-instances=0"
+      - "--max-instances=10"
+      - "--timeout=60"
+
+substitutions:
+  _REGISTRY: asia-northeast1-docker.pkg.dev
+  _REGION: asia-northeast1
+  _SERVICE_NAME: daily-report
+  _CLOUDSQL_INSTANCE: daily-report-db
+  _SECRET_DATABASE_URL: daily-report-database-url
+  _SECRET_NEXTAUTH_SECRET: daily-report-nextauth-secret
+  _NEXTAUTH_URL: https://daily-report-xxxxx-an.a.run.app
+
+images:
+  - "${_REGISTRY}/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:${SHORT_SHA}"
+  - "${_REGISTRY}/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:latest"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8


### PR DESCRIPTION
## 概要

Issue #4 の対応。Google Cloud Run へのデプロイに必要な設定ファイルを整備する。

## 対応内容

### Dockerfile（更新）
- `prisma generate` ステップを builder ステージに追加
  - ビルド時のみ dummy URL を使用（実際の DB 接続は不要）
  - `next build` の前に Prisma Client を生成することでビルドエラーを防止

### .dockerignore（更新）
| 追加除外 | 理由 |
|---------|------|
| `prisma/seed.ts` | 本番イメージに seed スクリプトは不要 |
| `coverage/` | テスト成果物を除外 |
| `.claude/` | エディタ設定を除外 |

### cloudbuild.yaml（新規作成）
Cloud Build によるビルド・デプロイパイプライン。

```
Docker build → Artifact Registry push → Cloud Run deploy
```

| 設定項目 | 値 |
|---------|---|
| Cloud SQL 接続 | `--add-cloudsql-instances` で Unix ソケット接続 |
| 機密情報 | Secret Manager から `DATABASE_URL` / `NEXTAUTH_SECRET` を注入 |
| メモリ | 512Mi |
| CPU | 1 |
| スケール | min 0 / max 10 |
| マシン | E2_HIGHCPU_8（ビルド高速化） |

### .github/workflows/cd.yml（更新）
| 変更点 | 内容 |
|--------|------|
| Cloud SQL | `--add-cloudsql-instances` を追加 |
| DATABASE_URL | `secrets.DATABASE_URL` → Secret Manager 参照 (`daily-report-database-url:latest`) |
| NEXTAUTH_SECRET | Secret Manager 参照 (`daily-report-nextauth-secret:latest`) |
| NEXTAUTH_URL | GitHub Repository Variables (`vars.NEXTAUTH_URL`) から取得 |
| Cloud Run オプション | メモリ・CPU・スケール設定を追加 |

### Makefile（更新）
| ターゲット | 内容 |
|-----------|------|
| `deploy` | Cloud SQL・Secret Manager オプション付きデプロイに更新 |
| `proxy` | Cloud SQL Auth Proxy 起動（ローカル開発用） |
| `migrate` | `prisma migrate deploy` を Prisma v7 config 付きで実行 |
| `seed` | `prisma db seed` を Prisma v7 config 付きで実行 |

## GCP 事前セットアップ（初回のみ）

```bash
# 1. Secret Manager にシークレットを登録
echo -n "postgresql://..." | gcloud secrets create daily-report-database-url --data-file=-
echo -n "your-nextauth-secret" | gcloud secrets create daily-report-nextauth-secret --data-file=-

# 2. GitHub Repository Variables に登録
#    Settings > Secrets and variables > Actions > Variables
#    NEXTAUTH_URL = https://daily-report-xxxxx-an.a.run.app

# 3. Workload Identity Federation を設定（GitHub Actions ↔ GCP 認証）
#    GCP_WORKLOAD_IDENTITY_PROVIDER / GCP_SERVICE_ACCOUNT を GitHub Secrets に登録
```

## ローカルでの Docker ビルド確認

```bash
make build   # Docker イメージをビルド
make push    # Artifact Registry へプッシュ
make deploy  # Cloud Run へデプロイ
```

## 受け入れ条件

- [x] `docker build` が正常完了すること（`prisma generate` 含む）
- [ ] Cloud Run にデプロイし、本番環境でアクセスできること（GCP 環境構築後に確認）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)